### PR TITLE
Non event emitter type support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,6 @@
 /*.sublime-workspace
 *.orig
 .DS_Store
+.cache
+.test
 coverage

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -12,11 +12,9 @@ module.exports = function(config) {
         bundlingEnabled: false,
         resolveCssUrls: true,
         cacheProfile: 'development',
-        // 2. tempdir is the directory where all the generated files will be stored.
         tempdir: './.test'
     },
 
-    // reporters configuration
     reporters: ['mocha'],
 
     plugins: [

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,0 +1,29 @@
+module.exports = function(config) {
+  config.set({
+    frameworks: ['lasso', 'mocha', 'chai'],
+
+    files: [
+      './test/browser/*.js'
+    ],
+
+    lasso: {
+        plugins: [],
+        minify: false,
+        bundlingEnabled: false,
+        resolveCssUrls: true,
+        cacheProfile: 'development',
+        // 2. tempdir is the directory where all the generated files will be stored.
+        tempdir: './.test'
+    },
+
+    // reporters configuration
+    reporters: ['mocha'],
+
+    plugins: [
+      'karma-chai',
+      'karma-lasso',
+      'karma-mocha',
+      'karma-mocha-reporter'
+    ]
+  });
+};

--- a/lib/listener-tracker.js
+++ b/lib/listener-tracker.js
@@ -1,6 +1,7 @@
 var INDEX_EVENT = 0;
 var INDEX_USER_LISTENER = 1;
 var INDEX_WRAPPED_LISTENER = 2;
+var ADD_EVENT_LISTENER = "addEventListener";
 
 function EventEmitterWrapper(target) {
     this._target = target;
@@ -10,7 +11,11 @@ function EventEmitterWrapper(target) {
 
 EventEmitterWrapper.prototype = {
     _onProxy: function(type, event, listener) {
-        this._target[type](event, listener);
+        if (this._target[type]) {
+          this._target[type](event, listener);
+        } else if (this._target[ADD_EVENT_LISTENER]) {
+          this._target[ADD_EVENT_LISTENER](event, listener);
+        }
         this._listeners.push([event, listener]);
         return this;
     },
@@ -203,9 +208,12 @@ SubscriptionTracker.prototype = {
 
 exports.wrap = function(targetEventEmitter) {
     var wrapper = new EventEmitterWrapper(targetEventEmitter);
-    targetEventEmitter.once('destroy', function() {
-        wrapper._listeners.length = 0;
-    });
+    if (targetEventEmitter.once) {
+      targetEventEmitter.once('destroy', function() {
+          wrapper._listeners.length = 0;
+      });
+    }
+
     return wrapper;
 };
 

--- a/lib/listener-tracker.js
+++ b/lib/listener-tracker.js
@@ -36,7 +36,12 @@ EventEmitterWrapper.prototype = {
                 // then we are attempting to remove based on a function that we had to
                 // wrap (not the user listener function)
                 if (curWrappedListenerFunc && test(curEvent, curWrappedListenerFunc)) {
-                    target.removeListener(curEvent, curWrappedListenerFunc);
+                    if (target.removeListener) {
+                      target.removeListener(curEvent, curWrappedListenerFunc);
+                    } else {
+                      target.removeEventListener(curEvent, curWrappedListenerFunc);
+                    }
+
                     return false;
                 }
             } else if (test(curEvent, curListenerFunc)) {
@@ -44,7 +49,12 @@ EventEmitterWrapper.prototype = {
                 // then we should remove from the target EventEmitter using wrapped
                 // listener function. Otherwise, we remove the listener using the user-provided
                 // listener function.
-                target.removeListener(curEvent, curWrappedListenerFunc || curListenerFunc);
+                if (target.removeListener) {
+                  target.removeListener(curEvent, curWrappedListenerFunc || curListenerFunc);
+                } else {
+                  target.removeEventListener(curEvent, curWrappedListenerFunc || curListenerFunc);
+                }
+
                 return false;
             }
 

--- a/lib/listener-tracker.js
+++ b/lib/listener-tracker.js
@@ -132,7 +132,11 @@ EventEmitterWrapper.prototype = {
         } else {
             for (var i = listeners.length - 1; i >= 0; i--) {
                 var cur = listeners[i];
-                target.removeListener(cur[INDEX_EVENT], cur[INDEX_USER_LISTENER]);
+                if (target.removeListener) {
+                  target.removeListener(cur[INDEX_EVENT], cur[INDEX_USER_LISTENER]);
+                } else {
+                  target.removeEventListener(cur[INDEX_EVENT], cur[INDEX_USER_LISTENER]);
+                }
             }
             this._listeners.length = 0;
         }

--- a/lib/listener-tracker.js
+++ b/lib/listener-tracker.js
@@ -25,11 +25,7 @@ EventEmitterWrapper.prototype = {
                 // then we are attempting to remove based on a function that we had to
                 // wrap (not the user listener function)
                 if (curWrappedListenerFunc && test(curEvent, curWrappedListenerFunc)) {
-                    if (target.removeListener) {
-                      target.removeListener(curEvent, curWrappedListenerFunc);
-                    } else {
-                      target.removeEventListener(curEvent, curWrappedListenerFunc);
-                    }
+                    target.removeListener(curEvent, curWrappedListenerFunc);
 
                     return false;
                 }
@@ -38,11 +34,7 @@ EventEmitterWrapper.prototype = {
                 // then we should remove from the target EventEmitter using wrapped
                 // listener function. Otherwise, we remove the listener using the user-provided
                 // listener function.
-                if (target.removeListener) {
-                  target.removeListener(curEvent, curWrappedListenerFunc || curListenerFunc);
-                } else {
-                  target.removeEventListener(curEvent, curWrappedListenerFunc || curListenerFunc);
-                }
+                target.removeListener(curEvent, curWrappedListenerFunc || curListenerFunc);
 
                 return false;
             }
@@ -66,11 +58,7 @@ EventEmitterWrapper.prototype = {
     },
 
     on: function(event, listener) {
-        if (this._target.on) {
-          this._target.on(event, listener);
-        } else {
-          this._target.addEventListener(event, listener);
-        }
+        this._target.on(event, listener);
         this._listeners.push([event, listener]);
         return this;
     },
@@ -89,16 +77,7 @@ EventEmitterWrapper.prototype = {
             listener.apply(this, arguments);
         };
 
-        if (this._target.once) {
-          this._target.once(event, wrappedListener);
-        } else {
-          // need to save this so we can remove it below
-          var onceListener = function() {
-            self._target.removeEventListener(event, onceListener);
-            wrappedListener();
-          };
-          this._target.addEventListener(event, onceListener);
-        }
+        this._target.once(event, wrappedListener);
         this._listeners.push([event, listener, wrappedListener]);
         return this;
     },
@@ -136,11 +115,7 @@ EventEmitterWrapper.prototype = {
         } else {
             for (var i = listeners.length - 1; i >= 0; i--) {
                 var cur = listeners[i];
-                if (target.removeListener) {
-                  target.removeListener(cur[INDEX_EVENT], cur[INDEX_USER_LISTENER]);
-                } else {
-                  target.removeEventListener(cur[INDEX_EVENT], cur[INDEX_USER_LISTENER]);
-                }
+                target.removeListener(cur[INDEX_EVENT], cur[INDEX_USER_LISTENER]);
             }
             this._listeners.length = 0;
         }
@@ -150,6 +125,34 @@ EventEmitterWrapper.prototype = {
 };
 
 EventEmitterWrapper.prototype.addListener = EventEmitterWrapper.prototype.on;
+
+function NonEventEmitterWrapper(target) {
+    this._target = target;
+}
+
+NonEventEmitterWrapper.prototype = {
+    on: function(event, listener) {
+        this._target.addEventListener(event, listener);
+        return this;
+    },
+
+    once: function(event, listener) {
+        var self = this;
+
+        // need to save this so we can remove it below
+        var onceListener = function() {
+          self._target.removeEventListener(event, onceListener);
+          listener();
+        };
+        this._target.addEventListener(event, onceListener);
+        return this;
+    },
+
+    removeListener: function(event, listener) {
+        this._target.removeEventListener(event, listener);
+        return this;
+    }
+};
 
 function SubscriptionTracker() {
     this._subscribeToList = [];
@@ -225,17 +228,24 @@ SubscriptionTracker.prototype = {
 };
 
 exports.wrap = function(targetEventEmitter) {
-    var wrapper = new EventEmitterWrapper(targetEventEmitter);
-    if (targetEventEmitter.once) {
-      targetEventEmitter.once('destroy', function() {
-          wrapper._listeners.length = 0;
-      });
-    } else {
+    var nonEE;
+    var wrapper;
+
+    if (!targetEventEmitter.once) {
+      nonEE = new NonEventEmitterWrapper(targetEventEmitter);
+    }
+
+    wrapper = new EventEmitterWrapper(nonEE || targetEventEmitter);
+    if (nonEE) {
       var listener = function() {
         wrapper._listeners.length = 0;
         targetEventEmitter.removeEventListener('DOMNodeRemovedFromDocument', listener);
       };
       targetEventEmitter.addEventListener('DOMNodeRemovedFromDocument', listener);
+    } else {
+      targetEventEmitter.once('destroy', function() {
+          wrapper._listeners.length = 0;
+      });
     }
 
     return wrapper;

--- a/lib/listener-tracker.js
+++ b/lib/listener-tracker.js
@@ -230,6 +230,12 @@ exports.wrap = function(targetEventEmitter) {
       targetEventEmitter.once('destroy', function() {
           wrapper._listeners.length = 0;
       });
+    } else {
+      var listener = function() {
+        wrapper._listeners.length = 0;
+        targetEventEmitter.removeEventListener('DOMNodeRemovedFromDocument', listener);
+      };
+      targetEventEmitter.addEventListener('DOMNodeRemovedFromDocument', listener);
     }
 
     return wrapper;

--- a/lib/listener-tracker.js
+++ b/lib/listener-tracker.js
@@ -1,7 +1,6 @@
 var INDEX_EVENT = 0;
 var INDEX_USER_LISTENER = 1;
 var INDEX_WRAPPED_LISTENER = 2;
-var ADD_EVENT_LISTENER = "addEventListener";
 
 function EventEmitterWrapper(target) {
     this._target = target;
@@ -10,16 +9,6 @@ function EventEmitterWrapper(target) {
 }
 
 EventEmitterWrapper.prototype = {
-    _onProxy: function(type, event, listener) {
-        if (this._target[type]) {
-          this._target[type](event, listener);
-        } else if (this._target[ADD_EVENT_LISTENER]) {
-          this._target[ADD_EVENT_LISTENER](event, listener);
-        }
-        this._listeners.push([event, listener]);
-        return this;
-    },
-
     _remove: function(test, testWrapped) {
         var target = this._target;
         var listeners = this._listeners;
@@ -77,7 +66,13 @@ EventEmitterWrapper.prototype = {
     },
 
     on: function(event, listener) {
-        return this._onProxy('on', event, listener);
+        if (this._target.on) {
+          this._target.on(event, listener);
+        } else {
+          this._target.addEventListener(event, listener);
+        }
+        this._listeners.push([event, listener]);
+        return this;
     },
 
     once: function(event, listener) {
@@ -94,7 +89,16 @@ EventEmitterWrapper.prototype = {
             listener.apply(this, arguments);
         };
 
-        this._target.once(event, wrappedListener);
+        if (this._target.once) {
+          this._target.once(event, wrappedListener);
+        } else {
+          // need to save this so we can remove it below
+          var onceListener = function() {
+            self._target.removeEventListener(event, onceListener);
+            wrappedListener();
+          };
+          this._target.addEventListener(event, onceListener);
+        }
         this._listeners.push([event, listener, wrappedListener]);
         return this;
     },

--- a/lib/listener-tracker.js
+++ b/lib/listener-tracker.js
@@ -126,11 +126,11 @@ EventEmitterWrapper.prototype = {
 
 EventEmitterWrapper.prototype.addListener = EventEmitterWrapper.prototype.on;
 
-function NonEventEmitterWrapper(target) {
+function EventEmitterAdapter(target) {
     this._target = target;
 }
 
-NonEventEmitterWrapper.prototype = {
+EventEmitterAdapter.prototype = {
     on: function(event, listener) {
         this._target.addEventListener(event, listener);
         return this;
@@ -232,7 +232,7 @@ exports.wrap = function(targetEventEmitter) {
     var wrapper;
 
     if (!targetEventEmitter.once) {
-      nonEE = new NonEventEmitterWrapper(targetEventEmitter);
+      nonEE = new EventEmitterAdapter(targetEventEmitter);
     }
 
     wrapper = new EventEmitterWrapper(nonEE || targetEventEmitter);

--- a/package.json
+++ b/package.json
@@ -1,32 +1,42 @@
 {
-    "name": "listener-tracker",
-    "description": "Allows event listeners to be tracked for easy removal",
-    "keywords": [
-        "events",
-        "listeners",
-        "EventEmitter"
-    ],
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/raptorjs/listener-tracker.git"
-    },
-    "scripts": {
-        "test": "node_modules/.bin/mocha --ui bdd --reporter spec ./test && node_modules/.bin/jshint lib/"
-    },
-    "author": "Patrick Steele-Idem <pnidem@gmail.com>",
-    "maintainers": [
-        "Patrick Steele-Idem <pnidem@gmail.com>",
-        "Phil Gates-Idem <phillip.idem@gmail.com>"
-    ],
-    "devDependencies": {
-        "chai": "^1.10.0",
-        "mocha": "^2.1.0",
-        "jshint": "^2.5.0"
-    },
-    "license": "Apache License v2.0",
-    "main": "lib/listener-tracker.js",
-    "publishConfig": {
-        "registry": "https://registry.npmjs.org/"
-    },
-    "version": "1.0.5"
+  "name": "listener-tracker",
+  "description": "Allows event listeners to be tracked for easy removal",
+  "keywords": [
+    "events",
+    "listeners",
+    "EventEmitter"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/raptorjs/listener-tracker.git"
+  },
+  "scripts": {
+    "test": "node_modules/.bin/mocha --ui bdd --reporter spec ./test && node_modules/.bin/jshint lib/",
+    "test-client": "node_modules/karma/bin/karma start"
+  },
+  "author": "Patrick Steele-Idem <pnidem@gmail.com>",
+  "maintainers": [
+    "Patrick Steele-Idem <pnidem@gmail.com>",
+    "Phil Gates-Idem <phillip.idem@gmail.com>"
+  ],
+  "devDependencies": {
+    "browserify": "^13.0.1",
+    "chai": "^1.10.0",
+    "jshint": "^2.5.0",
+    "karma": "^0.13.22",
+    "karma-browserify": "^5.0.5",
+    "karma-lasso": "^2.0.0",
+    "karma-mocha": "^1.0.1",
+    "karma-mocha-reporter": "^2.0.4",
+    "lasso": "^2.5.3",
+    "lasso-require": "^1.8.0",
+    "mocha": "^2.1.0",
+    "watchify": "^3.7.0"
+  },
+  "license": "Apache License v2.0",
+  "main": "lib/listener-tracker.js",
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/"
+  },
+  "version": "1.0.5"
 }

--- a/test/browser/test.js
+++ b/test/browser/test.js
@@ -4,7 +4,6 @@
 var chai = require('chai');
 chai.config.includeStack = true;
 var expect = chai.expect;
-var EventEmitter = require('events').EventEmitter;
 var listenerTracker = require('./../..');
 
 var createEvent = function(type) {
@@ -13,55 +12,41 @@ var createEvent = function(type) {
     return event;
 };
 
-var addListener = function(target, type, listener) {
-  target.on(type, listener);
-};
-
 var wrapped;
 var output;
+var TEST = "test";
+var MESSAGE = "works";
+var OUTPUT = [MESSAGE];
+var event = createEvent(TEST);
 var testFunc = function() {
-    output.push('works');
+    output.push(MESSAGE);
 };
 
-describe('client listener' , function() {
+describe('Non EventEmitter Suite' , function() {
     beforeEach(function() {
         output = [];
         wrapped = listenerTracker.wrap(window);
-    });
-
-    it('run', function() {
-        expect(4).to.equal(4);
-    });
-
-    it('test on with window', function() {
-        var event = createEvent("test");
-        addListener(wrapped, 'test', testFunc);
+        wrapped.on(TEST, testFunc);
         window.dispatchEvent(event);
-
-        expect(output).to.eql(['works']);
     });
 
-    it('test removeListeners for event with window', function() {
-        var event = createEvent("test2");
-        addListener(wrapped, 'test2', testFunc);
+    it('tests on', function() {
+        expect(output).to.eql(OUTPUT);
+    });
+
+    it('tests removeListeners for event', function() {
+        expect(output).to.eql(OUTPUT);
+
+        wrapped.removeAllListeners(TEST);
         window.dispatchEvent(event);
-        expect(output).to.eql(['works']);
-        output = [];
+        expect(output).to.eql(OUTPUT);
+    });
 
-        wrapped.removeAllListeners('test2');
+    it('tests removeListeners', function() {
+        expect(output).to.eql(OUTPUT);
+
+        wrapped.removeAllListeners();
         window.dispatchEvent(event);
-        expect(output).to.eql([]);
-    });
-
-    it('test removeListeners with window', function() {
-        // addListener(wrapped, 'test', testFunc);
-        // window.dispatchEvent(event);
-        //
-        // expect(output).to.eql(['works']);
-    });
-
-    it('event', function() {
-        var e = createEvent('resize');
-        expect(e).to.not.equal(null);
+        expect(output).to.eql(OUTPUT);
     });
 });

--- a/test/browser/test.js
+++ b/test/browser/test.js
@@ -15,11 +15,16 @@ var createEvent = function(type) {
 var wrapped;
 var output;
 var TEST = "test";
+var ONCE = "once";
 var MESSAGE = "works";
-var OUTPUT = [MESSAGE];
+var OUTPUT = [MESSAGE, ONCE];
 var event = createEvent(TEST);
+var onceEvent = createEvent(ONCE);
 var testFunc = function() {
     output.push(MESSAGE);
+};
+var onceFunc = function() {
+    output.push(ONCE);
 };
 
 describe('Non EventEmitter Suite' , function() {
@@ -27,10 +32,18 @@ describe('Non EventEmitter Suite' , function() {
         output = [];
         wrapped = listenerTracker.wrap(window);
         wrapped.on(TEST, testFunc);
+        wrapped.once(ONCE, onceFunc);
         window.dispatchEvent(event);
+        window.dispatchEvent(onceEvent);
     });
 
     it('tests on', function() {
+        expect(output).to.eql(OUTPUT);
+    });
+
+    it('tests once', function() {
+        expect(output).to.eql(OUTPUT);
+        window.dispatchEvent(onceEvent);
         expect(output).to.eql(OUTPUT);
     });
 

--- a/test/browser/test.js
+++ b/test/browser/test.js
@@ -13,13 +13,20 @@ var createEvent = function(type) {
     return event;
 };
 
-describe('client listener' , function() {
-    var wrapped;
-    var output;
-    var event = createEvent("test");
+var addListener = function(target, type, listener) {
+  target.on(type, listener);
+};
 
+var wrapped;
+var output;
+var testFunc = function() {
+    output.push('works');
+};
+
+describe('client listener' , function() {
     beforeEach(function() {
-      output = [];
+        output = [];
+        wrapped = listenerTracker.wrap(window);
     });
 
     it('run', function() {
@@ -27,22 +34,30 @@ describe('client listener' , function() {
     });
 
     it('test on with window', function() {
-        wrapped = listenerTracker.wrap(window);
-
-        wrapped.on('test', function() {
-            output.push('works');
-        });
-
+        var event = createEvent("test");
+        addListener(wrapped, 'test', testFunc);
         window.dispatchEvent(event);
 
         expect(output).to.eql(['works']);
     });
 
-    it('test removeListener with window', function() {
-        wrapped.removeAllListeners('test');
+    it('test removeListeners for event with window', function() {
+        var event = createEvent("test2");
+        addListener(wrapped, 'test2', testFunc);
         window.dispatchEvent(event);
+        expect(output).to.eql(['works']);
+        output = [];
 
+        wrapped.removeAllListeners('test2');
+        window.dispatchEvent(event);
         expect(output).to.eql([]);
+    });
+
+    it('test removeListeners with window', function() {
+        // addListener(wrapped, 'test', testFunc);
+        // window.dispatchEvent(event);
+        //
+        // expect(output).to.eql(['works']);
     });
 
     it('event', function() {

--- a/test/browser/test.js
+++ b/test/browser/test.js
@@ -1,0 +1,40 @@
+/* globals document, window */
+'use strict';
+
+var chai = require('chai');
+chai.config.includeStack = true;
+var expect = chai.expect;
+var EventEmitter = require('events').EventEmitter;
+var listenerTracker = require('./../..');
+
+var createEvent = function(type) {
+    var event = document.createEvent("HTMLEvents");
+    event.initEvent(type, true, true);
+    return event;
+};
+
+describe('client listener' , function() {
+    it('run', function() {
+        expect(4).to.equal(4);
+    });
+
+    it('test', function() {
+        var event = createEvent("test");
+        var wrapped = listenerTracker.wrap(window);
+
+        var output = [];
+
+        wrapped.on('test', function() {
+            output.push('works');
+        });
+
+        window.dispatchEvent(event);
+
+        expect(output).to.eql(['works']);
+    });
+
+    it('event', function() {
+        var e = createEvent('resize');
+        expect(e).to.not.equal(null);
+    });
+});

--- a/test/browser/test.js
+++ b/test/browser/test.js
@@ -14,15 +14,20 @@ var createEvent = function(type) {
 };
 
 describe('client listener' , function() {
+    var wrapped;
+    var output;
+    var event = createEvent("test");
+
+    beforeEach(function() {
+      output = [];
+    });
+
     it('run', function() {
         expect(4).to.equal(4);
     });
 
-    it('test', function() {
-        var event = createEvent("test");
-        var wrapped = listenerTracker.wrap(window);
-
-        var output = [];
+    it('test on with window', function() {
+        wrapped = listenerTracker.wrap(window);
 
         wrapped.on('test', function() {
             output.push('works');
@@ -31,6 +36,13 @@ describe('client listener' , function() {
         window.dispatchEvent(event);
 
         expect(output).to.eql(['works']);
+    });
+
+    it('test removeListener with window', function() {
+        wrapped.removeAllListeners('test');
+        window.dispatchEvent(event);
+
+        expect(output).to.eql([]);
     });
 
     it('event', function() {


### PR DESCRIPTION
This would allow browser related objects that emit and listen to events to work with listen-tracker (window, document, dom nodes), and not just instances of EventEmitter.

This adds functionality with `on`, `once`, `removeAllListeners('foo')`, and `removeAllListeners`. I think that covers all the bases. I'll make notes on some relevant pieces in the code as well.
