### PR TITLE
Non ee support for tracker

### DIFF
--- a/lib/listener-tracker.js
+++ b/lib/listener-tracker.js
@@ -2,7 +2,6 @@ var INDEX_EVENT = 0;
 var INDEX_USER_LISTENER = 1;
 var INDEX_WRAPPED_LISTENER = 2;
 var DESTROY = "destroy";
-var DOM_NODE_REMOVED_FROM_DOCUMENT = "DOMNodeRemovedFromDocument";
 
 function isNonEventEmitter(target) {
   return !target.once;
@@ -170,7 +169,6 @@ SubscriptionTracker.prototype = {
         var addDestroyListener = !options || options.addDestroyListener !== false;
         var wrapper;
         var nonEE;
-        var destroyEvent = DESTROY;
         var subscribeToList = this._subscribeToList;
 
         for (var i=0, len=subscribeToList.length; i<len; i++) {
@@ -184,12 +182,11 @@ SubscriptionTracker.prototype = {
         if (!wrapper) {
             if (isNonEventEmitter(target)) {
               nonEE = new EventEmitterAdapter(target);
-              destroyEvent = DOM_NODE_REMOVED_FROM_DOCUMENT;
             }
 
             wrapper = new EventEmitterWrapper(nonEE || target);
-            if (addDestroyListener) {
-                wrapper.once(destroyEvent, function() {
+            if (addDestroyListener && !nonEE) {
+                wrapper.once(DESTROY, function() {
                     wrapper.removeAllListeners();
 
                     for (var i = subscribeToList.length - 1; i >= 0; i--) {
@@ -247,15 +244,8 @@ exports.wrap = function(targetEventEmitter) {
     }
 
     wrapper = new EventEmitterWrapper(nonEE || targetEventEmitter);
-    if (nonEE) {
-      var listener = function() {
-        // we do this when el is removed from dom, which also sets
-        // _listeners to 0
-        wrapper.removeAllListeners();
-        targetEventEmitter.removeEventListener(DOM_NODE_REMOVED_FROM_DOCUMENT, listener);
-      };
-      targetEventEmitter.addEventListener(DOM_NODE_REMOVED_FROM_DOCUMENT, listener);
-    } else {
+    if (!nonEE) {
+      // we don't set this for non EE types
       targetEventEmitter.once(DESTROY, function() {
           wrapper._listeners.length = 0;
       });

--- a/lib/listener-tracker.js
+++ b/lib/listener-tracker.js
@@ -2,7 +2,7 @@ var INDEX_EVENT = 0;
 var INDEX_USER_LISTENER = 1;
 var INDEX_WRAPPED_LISTENER = 2;
 var DESTROY = "destroy";
-var DOM_NODE_REMVOED_FROM_DOCUMENT = "DOMNodeRemovedFromDocument";
+var DOM_NODE_REMOVED_FROM_DOCUMENT = "DOMNodeRemovedFromDocument";
 
 function isNonEventEmitter(target) {
   return !target.once;
@@ -184,7 +184,7 @@ SubscriptionTracker.prototype = {
         if (!wrapper) {
             if (isNonEventEmitter(target)) {
               nonEE = new EventEmitterAdapter(target);
-              destroyEvent = DOM_NODE_REMVOED_FROM_DOCUMENT;
+              destroyEvent = DOM_NODE_REMOVED_FROM_DOCUMENT;
             }
 
             wrapper = new EventEmitterWrapper(nonEE || target);
@@ -252,9 +252,9 @@ exports.wrap = function(targetEventEmitter) {
         // we do this when el is removed from dom, which also sets
         // _listeners to 0
         wrapper.removeAllListeners();
-        targetEventEmitter.removeEventListener(DOM_NODE_REMVOED_FROM_DOCUMENT, listener);
+        targetEventEmitter.removeEventListener(DOM_NODE_REMOVED_FROM_DOCUMENT, listener);
       };
-      targetEventEmitter.addEventListener(DOM_NODE_REMVOED_FROM_DOCUMENT, listener);
+      targetEventEmitter.addEventListener(DOM_NODE_REMOVED_FROM_DOCUMENT, listener);
     } else {
       targetEventEmitter.once(DESTROY, function() {
           wrapper._listeners.length = 0;

--- a/lib/listener-tracker.js
+++ b/lib/listener-tracker.js
@@ -1,6 +1,12 @@
 var INDEX_EVENT = 0;
 var INDEX_USER_LISTENER = 1;
 var INDEX_WRAPPED_LISTENER = 2;
+var DESTROY = "destroy";
+var DOM_NODE_REMVOED_FROM_DOCUMENT = "DOMNodeRemovedFromDocument";
+
+function isNonEventEmitter(target) {
+  return !target.once;
+}
 
 function EventEmitterWrapper(target) {
     this._target = target;
@@ -151,6 +157,30 @@ EventEmitterAdapter.prototype = {
     removeListener: function(event, listener) {
         this._target.removeEventListener(event, listener);
         return this;
+    },
+
+    removeAllListeners: function(event) {
+      var listeners = this._listeners;
+      var target = this._target;
+      var i;
+      var cur;
+
+      if (event) {
+          for(i = listeners.length - 1; i >= 0; i++) {
+            cur = listeners[i];
+            if (event === cur[INDEX_EVENT]) {
+              target.removeEventListener(event, cur[INDEX_USER_LISTENER]);
+            }
+          }
+      } else {
+          for (i = listeners.length - 1; i >= 0; i--) {
+              cur = listeners[i];
+              target.removeListener(cur[INDEX_EVENT], cur[INDEX_USER_LISTENER]);
+          }
+          this._listeners.length = 0;
+      }
+
+      return this;
     }
 };
 
@@ -162,8 +192,9 @@ SubscriptionTracker.prototype = {
 
     subscribeTo: function(target, options) {
         var addDestroyListener = !options || options.addDestroyListener !== false;
-
         var wrapper;
+        var nonEE;
+        var destroyEvent = DESTROY;
         var subscribeToList = this._subscribeToList;
 
         for (var i=0, len=subscribeToList.length; i<len; i++) {
@@ -175,9 +206,14 @@ SubscriptionTracker.prototype = {
         }
 
         if (!wrapper) {
-            wrapper = new EventEmitterWrapper(target);
+            if (isNonEventEmitter(target)) {
+              nonEE = new EventEmitterAdapter(target);
+              destroyEvent = DOM_NODE_REMVOED_FROM_DOCUMENT;
+            }
+
+            wrapper = new EventEmitterWrapper(nonEE || target);
             if (addDestroyListener) {
-                wrapper.once('destroy', function() {
+                wrapper.once(destroyEvent, function() {
                     wrapper.removeAllListeners();
 
                     for (var i = subscribeToList.length - 1; i >= 0; i--) {
@@ -218,7 +254,6 @@ SubscriptionTracker.prototype = {
                 }
             }
         } else {
-
             for (i = subscribeToList.length - 1; i >= 0; i--) {
                 subscribeToList[i].removeAllListeners();
             }
@@ -231,19 +266,21 @@ exports.wrap = function(targetEventEmitter) {
     var nonEE;
     var wrapper;
 
-    if (!targetEventEmitter.once) {
+    if (isNonEventEmitter(targetEventEmitter)) {
       nonEE = new EventEmitterAdapter(targetEventEmitter);
     }
 
     wrapper = new EventEmitterWrapper(nonEE || targetEventEmitter);
     if (nonEE) {
       var listener = function() {
-        wrapper._listeners.length = 0;
-        targetEventEmitter.removeEventListener('DOMNodeRemovedFromDocument', listener);
+        // we do this when el is removed from dom, which also sets
+        // _listeners to 0
+        wrapper.removeAllListeners();
+        targetEventEmitter.removeEventListener(DOM_NODE_REMVOED_FROM_DOCUMENT, listener);
       };
-      targetEventEmitter.addEventListener('DOMNodeRemovedFromDocument', listener);
+      targetEventEmitter.addEventListener(DOM_NODE_REMVOED_FROM_DOCUMENT, listener);
     } else {
-      targetEventEmitter.once('destroy', function() {
+      targetEventEmitter.once(DESTROY, function() {
           wrapper._listeners.length = 0;
       });
     }

--- a/lib/listener-tracker.js
+++ b/lib/listener-tracker.js
@@ -157,30 +157,6 @@ EventEmitterAdapter.prototype = {
     removeListener: function(event, listener) {
         this._target.removeEventListener(event, listener);
         return this;
-    },
-
-    removeAllListeners: function(event) {
-      var listeners = this._listeners;
-      var target = this._target;
-      var i;
-      var cur;
-
-      if (event) {
-          for(i = listeners.length - 1; i >= 0; i++) {
-            cur = listeners[i];
-            if (event === cur[INDEX_EVENT]) {
-              target.removeEventListener(event, cur[INDEX_USER_LISTENER]);
-            }
-          }
-      } else {
-          for (i = listeners.length - 1; i >= 0; i--) {
-              cur = listeners[i];
-              target.removeListener(cur[INDEX_EVENT], cur[INDEX_USER_LISTENER]);
-          }
-          this._listeners.length = 0;
-      }
-
-      return this;
     }
 };
 

--- a/test/browser/test.js
+++ b/test/browser/test.js
@@ -20,6 +20,7 @@ var ONCE = "once";
 var MESSAGE = "works";
 var OUTPUT = [MESSAGE, ONCE];
 var event = createEvent(TEST);
+var domNodeRemoved = createEvent("DOMNodeRemovedFromDocument");
 var onceEvent = createEvent(ONCE);
 var testFunc = function() {
     output.push(MESSAGE);
@@ -63,6 +64,14 @@ describe('Non EventEmitter Wrap Suite' , function() {
         window.dispatchEvent(event);
         expect(output).to.eql(OUTPUT);
     });
+
+    it('tests the destroy listener', function() {
+        expect(output).to.eql(OUTPUT);
+        // destroy listener is added by default
+        window.dispatchEvent(domNodeRemoved);
+        window.dispatchEvent(event);
+        expect(output).to.eql(OUTPUT);
+    });
 });
 
 describe('Non EventEmitter Tracker Suite' , function() {
@@ -89,6 +98,14 @@ describe('Non EventEmitter Tracker Suite' , function() {
         expect(output).to.eql(OUTPUT);
 
         tracker.removeAllListeners();
+        window.dispatchEvent(event);
+        expect(output).to.eql(OUTPUT);
+    });
+
+    it('tests the destroy listener', function() {
+        expect(output).to.eql(OUTPUT);
+        // destroy listener is added by default
+        window.dispatchEvent(domNodeRemoved);
         window.dispatchEvent(event);
         expect(output).to.eql(OUTPUT);
     });

--- a/test/browser/test.js
+++ b/test/browser/test.js
@@ -14,6 +14,7 @@ var createEvent = function(type) {
 
 var wrapped;
 var output;
+var tracker;
 var TEST = "test";
 var ONCE = "once";
 var MESSAGE = "works";
@@ -27,7 +28,7 @@ var onceFunc = function() {
     output.push(ONCE);
 };
 
-describe('Non EventEmitter Suite' , function() {
+describe('Non EventEmitter Wrap Suite' , function() {
     beforeEach(function() {
         output = [];
         wrapped = listenerTracker.wrap(window);
@@ -47,7 +48,7 @@ describe('Non EventEmitter Suite' , function() {
         expect(output).to.eql(OUTPUT);
     });
 
-    it('tests removeListeners for event', function() {
+    it('tests removeAllListeners for event', function() {
         expect(output).to.eql(OUTPUT);
 
         wrapped.removeAllListeners(TEST);
@@ -55,10 +56,39 @@ describe('Non EventEmitter Suite' , function() {
         expect(output).to.eql(OUTPUT);
     });
 
-    it('tests removeListeners', function() {
+    it('tests removeAllListeners', function() {
         expect(output).to.eql(OUTPUT);
 
         wrapped.removeAllListeners();
+        window.dispatchEvent(event);
+        expect(output).to.eql(OUTPUT);
+    });
+});
+
+describe('Non EventEmitter Tracker Suite' , function() {
+    beforeEach(function() {
+        output = [];
+        tracker = listenerTracker.createTracker();
+        tracker.subscribeTo(window).on(TEST, testFunc);
+        tracker.subscribeTo(window).once(ONCE, onceFunc);
+        window.dispatchEvent(event);
+        window.dispatchEvent(onceEvent);
+    });
+
+    it('tests on', function() {
+        expect(output).to.eql(OUTPUT);
+    });
+
+    it('tests once', function() {
+        expect(output).to.eql(OUTPUT);
+        window.dispatchEvent(onceEvent);
+        expect(output).to.eql(OUTPUT);
+    });
+
+    it('tests removeAllListeners for event', function() {
+        expect(output).to.eql(OUTPUT);
+
+        tracker.removeAllListeners();
         window.dispatchEvent(event);
         expect(output).to.eql(OUTPUT);
     });

--- a/test/browser/test.js
+++ b/test/browser/test.js
@@ -15,6 +15,8 @@ var createEvent = function(type) {
 var wrapped;
 var output;
 var tracker;
+var paragraphEl = document.createElement("p");
+document.getElementsByTagName("body")[0].appendChild(paragraphEl);
 var TEST = "test";
 var ONCE = "once";
 var MESSAGE = "works";
@@ -32,11 +34,11 @@ var onceFunc = function() {
 describe('Non EventEmitter Wrap Suite' , function() {
     beforeEach(function() {
         output = [];
-        wrapped = listenerTracker.wrap(window);
+        wrapped = listenerTracker.wrap(paragraphEl);
         wrapped.on(TEST, testFunc);
         wrapped.once(ONCE, onceFunc);
-        window.dispatchEvent(event);
-        window.dispatchEvent(onceEvent);
+        paragraphEl.dispatchEvent(event);
+        paragraphEl.dispatchEvent(onceEvent);
     });
 
     it('tests on', function() {
@@ -45,7 +47,7 @@ describe('Non EventEmitter Wrap Suite' , function() {
 
     it('tests once', function() {
         expect(output).to.eql(OUTPUT);
-        window.dispatchEvent(onceEvent);
+        paragraphEl.dispatchEvent(onceEvent);
         expect(output).to.eql(OUTPUT);
     });
 
@@ -53,7 +55,7 @@ describe('Non EventEmitter Wrap Suite' , function() {
         expect(output).to.eql(OUTPUT);
 
         wrapped.removeAllListeners(TEST);
-        window.dispatchEvent(event);
+        paragraphEl.dispatchEvent(event);
         expect(output).to.eql(OUTPUT);
     });
 
@@ -61,15 +63,16 @@ describe('Non EventEmitter Wrap Suite' , function() {
         expect(output).to.eql(OUTPUT);
 
         wrapped.removeAllListeners();
-        window.dispatchEvent(event);
+        paragraphEl.dispatchEvent(event);
         expect(output).to.eql(OUTPUT);
     });
 
     it('tests the destroy listener', function() {
         expect(output).to.eql(OUTPUT);
-        // destroy listener is added by default
-        window.dispatchEvent(domNodeRemoved);
-        window.dispatchEvent(event);
+        // destroy listener is added by default, so just need to remove
+        // to fire event
+        paragraphEl.remove();
+        paragraphEl.dispatchEvent(event);
         expect(output).to.eql(OUTPUT);
     });
 });

--- a/test/browser/test.js
+++ b/test/browser/test.js
@@ -1,4 +1,4 @@
-/* globals document, window */
+/* globals document, window, describe, beforeEach, it */
 'use strict';
 
 var chai = require('chai');
@@ -21,8 +21,7 @@ var TEST = "test";
 var ONCE = "once";
 var MESSAGE = "works";
 var OUTPUT = [MESSAGE, ONCE];
-var event = createEvent(TEST);
-var domNodeRemoved = createEvent("DOMNodeRemovedFromDocument");
+var testEvent = createEvent(TEST);
 var onceEvent = createEvent(ONCE);
 var testFunc = function() {
     output.push(MESSAGE);
@@ -37,7 +36,7 @@ describe('Non EventEmitter Wrap Suite' , function() {
         wrapped = listenerTracker.wrap(paragraphEl);
         wrapped.on(TEST, testFunc);
         wrapped.once(ONCE, onceFunc);
-        paragraphEl.dispatchEvent(event);
+        paragraphEl.dispatchEvent(testEvent);
         paragraphEl.dispatchEvent(onceEvent);
     });
 
@@ -55,7 +54,7 @@ describe('Non EventEmitter Wrap Suite' , function() {
         expect(output).to.eql(OUTPUT);
 
         wrapped.removeAllListeners(TEST);
-        paragraphEl.dispatchEvent(event);
+        paragraphEl.dispatchEvent(testEvent);
         expect(output).to.eql(OUTPUT);
     });
 
@@ -63,16 +62,7 @@ describe('Non EventEmitter Wrap Suite' , function() {
         expect(output).to.eql(OUTPUT);
 
         wrapped.removeAllListeners();
-        paragraphEl.dispatchEvent(event);
-        expect(output).to.eql(OUTPUT);
-    });
-
-    it('tests the destroy listener', function() {
-        expect(output).to.eql(OUTPUT);
-        // destroy listener is added by default, so just need to remove
-        // to fire event
-        paragraphEl.remove();
-        paragraphEl.dispatchEvent(event);
+        paragraphEl.dispatchEvent(testEvent);
         expect(output).to.eql(OUTPUT);
     });
 });
@@ -83,7 +73,7 @@ describe('Non EventEmitter Tracker Suite' , function() {
         tracker = listenerTracker.createTracker();
         tracker.subscribeTo(window).on(TEST, testFunc);
         tracker.subscribeTo(window).once(ONCE, onceFunc);
-        window.dispatchEvent(event);
+        window.dispatchEvent(testEvent);
         window.dispatchEvent(onceEvent);
     });
 
@@ -101,15 +91,7 @@ describe('Non EventEmitter Tracker Suite' , function() {
         expect(output).to.eql(OUTPUT);
 
         tracker.removeAllListeners();
-        window.dispatchEvent(event);
-        expect(output).to.eql(OUTPUT);
-    });
-
-    it('tests the destroy listener', function() {
-        expect(output).to.eql(OUTPUT);
-        // destroy listener is added by default
-        window.dispatchEvent(domNodeRemoved);
-        window.dispatchEvent(event);
+        window.dispatchEvent(testEvent);
         expect(output).to.eql(OUTPUT);
     });
 });


### PR DESCRIPTION
Well looks like I forgot to add similar support for the `tracker` :confused: This PR adds support for that as well as more robust tests.
